### PR TITLE
New-AsBuiltReport.ps1 - Fix CWD paths

### DIFF
--- a/New-AsBuiltReport.ps1
+++ b/New-AsBuiltReport.ps1
@@ -138,8 +138,7 @@ Elseif (!$Credentials -and (!($Username -and !($Password)))) {
 }
 
 # Set variables from report configuration JSON file
-$ScriptPath = (Get-Location).Path
-$ReportConfigFile = Join-Path $ScriptPath $("Reports\$Type\$Type.json")
+$ReportConfigFile = "$PSScriptRoot\Reports\$Type\$Type.json"
 If (Test-Path $ReportConfigFile -ErrorAction SilentlyContinue) {  
     $ReportConfig = Get-Content $ReportConfigFile | ConvertFrom-json
     $Report = $ReportConfig.Report
@@ -264,9 +263,9 @@ else {
         if (($AsBuiltName -eq $null) -or ($AsBuiltName -eq "")) {
             $AsBuiltName = "AsBuiltConfig"
         }
-        $AsBuiltExportPath = Read-Host -Prompt "Enter the path to save the As Built report configuration file [$ScriptPath]"
+        $AsBuiltExportPath = Read-Host -Prompt "Enter the path to save the As Built report configuration file [$PSScriptRoot]"
         if (($AsBuiltExportPath -eq $null) -or ($AsBuiltExportPath -eq "")) {
-            $AsBuiltExportPath = $ScriptPath
+            $AsBuiltExportPath = $PSScriptRoot
         }
         $AsBuiltConfigPath = Join-Path $AsBuiltExportPath $("$AsBuiltName.json")
         $BaseConfig = Get-Content $AsBuiltConfigPath | ConvertFrom-Json
@@ -435,18 +434,18 @@ Clear-Host
 $AsBuiltReport = Document $FileName -Verbose {
     # Set document style
     if ($StyleName) {
-        $DocStyle = Join-Path $ScriptPath $("Styles\$StyleName.ps1")
-        If (Test-Path $DocStyle -ErrorAction SilentlyContinue) {
+        $DocStyle = "$PSScriptRoot\Styles\$StyleName.ps1"
+        if (Test-Path $DocStyle -ErrorAction SilentlyContinue) {
             .$DocStyle 
         }
         else {
-            Write-Warning "Style name $Stylename does not exist"
+            Write-Warning "Style name $StyleName does not exist"
         }
     }
     # Generate report
     if ($Type) {
-        $ScriptFile = Join-Path $ScriptPath $("Reports\$Type\$Type.ps1")
-        if (Test-Path $scriptFile -ErrorAction SilentlyContinue) {
+        $ScriptFile = "$PSScriptRoot\Reports\$Type\$Type.ps1"
+        if (Test-Path $ScriptFile -ErrorAction SilentlyContinue) {
             .$ScriptFile
         }
         else {

--- a/Reports/vSphere/vSphere.ps1
+++ b/Reports/vSphere/vSphere.ps1
@@ -27,7 +27,7 @@ $VIServer = @()
 
 # If custom style not set, use VMware style
 if (!$StyleName) {
-    .\Styles\VMware.ps1
+    & "$PSScriptRoot\..\..\Styles\VMware.ps1"
 }
 
 #endregion Configuration Settings


### PR DESCRIPTION
Currently the script has to be run with the current working directory set to the root of the project. This fixes that by assigning `$PSScriptRoot` instead.