### PR TITLE
Correct VM Guest OS reporting and SCSI LUN Information Sort Order

### DIFF
--- a/Reports/vSphere/vSphere.ps1
+++ b/Reports/vSphere/vSphere.ps1
@@ -1564,7 +1564,7 @@ foreach ($VIServer in $Target) {
                                                 'Multipath Policy' = $ScsiDeviceDetail.MultipathPolicy
                                             }
                                         }
-                                        $ScsiLuns | Table -Name 'SCSI LUN Information'
+                                        $ScsiLuns | Sort-Object Host | Table -Name 'SCSI LUN Information'
                                     }
                                 }
                             }
@@ -1751,7 +1751,7 @@ foreach ($VIServer in $Target) {
                         foreach ($VM in $VMs) {
                             Section -Style Heading3 $VM.name {
                                 $VMSpecs = $VM | Select-Object Name, id, 
-                                @{L = 'Operating System'; E = {$_.Guest.OSFullName}}, 
+                                @{L = 'Operating System'; E = {$_.ExtensionData.Summary.Config.GuestFullName}}, 
                                 @{L = 'Hardware Version'; E = {$_.Version}}, 
                                 @{L = 'Power State'; E = {$_.PowerState}}, 
                                 @{L = 'VM Tools Status'; E = {$_.ExtensionData.Guest.ToolsStatus}},


### PR DESCRIPTION
## Description
Fixes minor issues within vSphere As Built Report in regards to VM GuestOS Name & SCSI LUN Sort Order

## Related Issue
#32 & #33 

## Motivation and Context
Improve report quality of vSphere As Built Report

## How Has This Been Tested?
Test vSphere As Built Report against Production & Lab environments.


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
