### PR TITLE
Add Raw parameter when importing JSON data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # New-AsBuiltReport Changelog
 
+## [Unreleased]
+### Changed
+- Add "-Raw" paramter to get-content when importing report JSON data to fix a known issue
+
 ## 0.3.0
 
 ### What's New

--- a/Src/Public/New-AsBuiltReport.ps1
+++ b/Src/Public/New-AsBuiltReport.ps1
@@ -147,7 +147,7 @@ function New-AsBuiltReport {
     # Set variables from report configuration JSON file
     $ReportConfigFile = "$PSScriptRoot\Reports\$Type\$Type.json"
     If (Test-Path $ReportConfigFile -ErrorAction SilentlyContinue) {  
-        $ReportConfig = Get-Content $ReportConfigFile | ConvertFrom-json
+        $ReportConfig = Get-Content $ReportConfigFile -Raw | ConvertFrom-json
         $Report = $ReportConfig.Report
         $ReportName = $Report.Name
         $Version = $Report.Version
@@ -175,7 +175,7 @@ function New-AsBuiltReport {
             Write-Error "The path specified for the As Built configuration file can not be resolved"
             break
         } else {
-            $BaseConfig = Get-Content $AsBuiltConfigPath | ConvertFrom-Json
+            $BaseConfig = Get-Content $AsBuiltConfigPath -Raw | ConvertFrom-Json
             $Author = $BaseConfig.Report.Author
             $Company = $BaseConfig.Company
             $MailServer = $BaseConfig.Mail.Server
@@ -270,7 +270,7 @@ function New-AsBuiltReport {
                 $AsBuiltExportPath = $PSScriptRoot
             }
             $AsBuiltConfigPath = Join-Path $AsBuiltExportPath $("$AsBuiltName.json")
-            $BaseConfig = Get-Content $AsBuiltConfigPath | ConvertFrom-Json
+            $BaseConfig = Get-Content $AsBuiltConfigPath -Raw | ConvertFrom-Json
         }
 
         Clear-Host
@@ -398,7 +398,7 @@ function New-AsBuiltReport {
         }
         if ($SaveAsBuiltConfig -eq "y") {
             $Body | ConvertTo-Json -Depth 10 | Out-File $AsBuiltConfigPath
-            $BaseConfig = Get-Content $AsBuiltConfigPath | ConvertFrom-Json
+            $BaseConfig = Get-Content $AsBuiltConfigPath -Raw | ConvertFrom-Json
             $Author = $BaseConfig.Report.Author
             $Company = $BaseConfig.Company
             $Mail = $BaseConfig.Mail
@@ -411,7 +411,7 @@ function New-AsBuiltReport {
             }
         } else {
             $Body | ConvertTo-Json -depth 10 | Out-File "$env:TEMP\AsBuiltReport.json" -Force
-            $BaseConfig = Get-Content "$env:TEMP\AsBuiltReport.json" | ConvertFrom-Json
+            $BaseConfig = Get-Content "$env:TEMP\AsBuiltReport.json" -Raw | ConvertFrom-Json
             $Author = $BaseConfig.Report.Author
             $Company = $BaseConfig.Company
             $Mail = $BaseConfig.Mail


### PR DESCRIPTION
- Add "-Raw" paramter to get-content when importing report JSON data to fix a known issue
- Provides a fix for Issue #40