### PR TITLE
Add PCI devices drivers and firmwares details for VMhosts

### DIFF
--- a/Src/Public/Reports/vSphere/vSphere.ps1
+++ b/Src/Public/Reports/vSphere/vSphere.ps1
@@ -411,7 +411,7 @@ function Get-ScsiDeviceDetail {
     }
 }
 
-Function Get-PcideviceDetail {
+Function Get-PciDeviceDetail {
     <#
     .SYNOPSIS
     Helper function to return PCI Devices Drivers & Firmware information for a specific host.
@@ -424,7 +424,7 @@ Function Get-PcideviceDetail {
     $Server = Connect-VIServer -Server vcenter01.example.com -Credentials $Credentials
     $VMHost = Get-VMHost -Server $Server -Name esx01.example.com
     $esxcli = Get-EsxCli -Server $Server -VMHost $VMhost -V2
-    Get-PCIdeviceDetail -Server $vCenter -esxcli $esxcli
+    Get-PciDeviceDetail -Server $vCenter -esxcli $esxcli
 
     VMkernel Name    : vmhba0
     Device Name      : Sunrise Point-LP AHCI Controller
@@ -1012,7 +1012,7 @@ foreach ($VIServer in $Target) {
 
                                     #region ESXi Host PCI Devices Drivers & Firmware
                                     Section -Style Heading5 'PCI Devices Drivers & Firmware' {
-                                        $VMhostPciDevicesDetails = Get-PcideviceDetail -Server $vCenter -esxcli $esxcli | Sort-Object 'VMKernel Name' 
+                                        $VMhostPciDevicesDetails = Get-PciDeviceDetail -Server $vCenter -esxcli $esxcli | Sort-Object 'VMkernel Name' 
                                         $VMhostPciDevicesDetails | Table -Name "$VMhost PCI Devices Drivers & Firmware" 
                                     }
                                     #endregion ESXi Host PCI Devices Drivers & Firmware
@@ -1190,8 +1190,8 @@ foreach ($VIServer in $Target) {
                                     BlankLine
                                     #region ESXi Host Network Configuration
                                     $VMHostNetwork = $VMhost | Get-VMHostNetwork | Select-Object  VMHost, @{L = 'Virtual Switches'; E = {($_.VirtualSwitch) -join ", "}}, @{L = 'VMkernel Adapters'; E = {($_.VirtualNic) -join ", "}}, 
-                                    @{L = 'Physical Adapters'; E = {($_.PhysicalNic) -join ", "}}, @{L = 'VMKernel Gateway'; E = {$_.VMKernelGateway}}, @{L = 'IPv6 Enabled'; E = {$_.IPv6Enabled}}, 
-                                    @{L = 'VMKernel IPv6 Gateway'; E = {$_.VMKernelV6Gateway}}, @{L = 'DNS Servers'; E = {($_.DnsAddress) -join ", "}}, @{L = 'Host Name'; E = {$_.HostName}}, 
+                                    @{L = 'Physical Adapters'; E = {($_.PhysicalNic) -join ", "}}, @{L = 'VMkernel Gateway'; E = {$_.VMKernelGateway}}, @{L = 'IPv6 Enabled'; E = {$_.IPv6Enabled}}, 
+                                    @{L = 'VMkernel IPv6 Gateway'; E = {$_.VMKernelV6Gateway}}, @{L = 'DNS Servers'; E = {($_.DnsAddress) -join ", "}}, @{L = 'Host Name'; E = {$_.HostName}}, 
                                     @{L = 'Domain Name'; E = {$_.DomainName}}, @{L = 'Search Domain'; E = {($_.SearchDomain) -join ", "}}
                                     if ($Healthcheck.VMHost.IPv6Enabled) {
                                         $VMHostNetwork | Where-Object {$_.'IPv6 Enabled' -eq $false} | Set-Style -Style Warning -Property 'IPv6 Enabled'

--- a/Src/Public/Reports/vSphere/vSphere.ps1
+++ b/Src/Public/Reports/vSphere/vSphere.ps1
@@ -410,6 +410,106 @@ function Get-ScsiDeviceDetail {
         'CapacityGB' = $CapacityGB
     }
 }
+
+Function Get-PCIdeviceDetail {
+    <#
+    .SYNOPSIS
+    Helper function to return PCI device driver and firmware information for a specific host.
+    .PARAMETER Server
+    vCenter VISession object.
+    .PARAMETER esxcli
+    Esxcli session object associated to the host.
+    .EXAMPLE
+    $Credentials = Get-Crendentials
+    $Server = Connect-VIServer -Server vcenter01.example.com -Credentials $Credentials
+    $VMHost = Get-VMHost -Server $Server -Name esx01.example.com
+    $esxcli = Get-EsxCli -Server $Server -VMHost $VMhost -V2
+    Get-PCIdeviceDetail -Server $vCenter -esxcli $esxcli
+
+    VMKernel Name    : vmhba0
+    Device Name      : Sunrise Point-LP AHCI Controller
+    Driver           : vmw_ahci
+    Driver Version   : 1.0.0-34vmw.650.0.14.5146846
+    Firmware Version : NA
+    VIB Name         : vmw-ahci
+    VIB Version      : 1.0.0-34vmw.650.0.14.5146846
+
+    .NOTES
+    Author: Erwan Quelin heavily based on the work of the vDocumentation team - https://github.com/arielsanchezmora/vDocumentation/blob/master/powershell/vDocumentation/Public/Get-ESXIODevice.ps1
+    #>
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory = $true)]
+        $Server,
+        [Parameter(Mandatory = $true)]
+        $esxcli
+    )
+
+    Begin {}
+    
+    Process {
+
+        # Set default results
+        $firmwareVersion = "NA"
+        $vibName = "NA"
+        $driverVib = @{
+            Name = "NA"
+            Version = "NA"
+        }
+
+        $pciDevices = $esxcli.hardware.pci.list.Invoke() | Where-Object {$_.VMKernelName -like "vmhba*" -or $_.VMKernelName -like "vmnic*" -or $_.VMKernelName -like "vmgfx*"} | Sort-Object -Property VMKernelName 
+
+        foreach ($pciDevice in $pciDevices) {
+            $driverVersion = $esxcli.system.module.get.Invoke(@{module = $pciDevice.ModuleName}) | Select-Object -ExpandProperty Version
+
+            <#
+                Get NIC Firmware version
+            #>
+            if ($pciDevice.VMKernelName -like 'vmnic*') {
+                $vmnicDetail = $esxcli.network.nic.get.Invoke(@{nicname = $pciDevice.VMKernelName})
+                $firmwareVersion = $vmnicDetail.DriverInfo.FirmwareVersion
+                
+                <#
+                    Get NIC driver VIB package version
+                #>
+                $driverVib = $esxcli.software.vib.list.Invoke() | Select-Object -Property Name, Version | Where-Object {$_.Name -eq $vmnicDetail.DriverInfo.Driver -or $_.Name -eq "net-" + $vmnicDetail.DriverInfo.Driver -or $_.Name -eq "net55-" + $vmnicDetail.DriverInfo.Driver}
+                <#
+                    If HP Smart Array vmhba* (scsi-hpsa driver) then get Firmware version
+                    else skip if VMkernnel is vmhba*. Can't get HBA Firmware from 
+                    Powercli at the moment only through SSH or using Putty Plink+PowerCli.
+                #>
+            }
+            elseif ($pciDevice.VMKernelName -like 'vmhba*') {
+                if ($pciDevice.DeviceName -match "smart array") {
+                    $hpsa = $vmhost.ExtensionData.Runtime.HealthSystemRuntime.SystemHealthInfo.NumericSensorInfo | Where-Object {$_.Name -match "HP Smart Array"}
+                    if ($hpsa) {
+                        $firmwareVersion = (($hpsa.Name -split "firmware")[1]).Trim()
+                    }
+                }
+                <#
+                    Get HBA driver VIB package version
+                #>
+                $vibName = $pciDevice.ModuleName -replace "_", "-"
+                $driverVib = $esxcli.software.vib.list.Invoke() | Select-Object -Property Name, Version | Where-Object {$_.Name -eq "scsi-" + $VibName -or $_.Name -eq "sata-" + $VibName -or $_.Name -eq $VibName}
+            }
+            <#
+                Output collected data
+            #>
+            [PSCustomObject]@{
+                'VMKernel Name'    = $pciDevice.VMKernelName
+                'Device Name'      = $pciDevice.DeviceName
+                'Driver'           = $pciDevice.ModuleName
+                'Driver Version'   = $driverVersion
+                'Firmware Version' = $firmwareVersion
+                'VIB Name'         = $driverVib.Name
+                'VIB Version'      = $driverVib.Version
+            } 
+        } 
+    }
+
+    End{}
+    
+}
 #endregion Script Functions
 
 #region Script Body
@@ -909,6 +1009,15 @@ foreach ($VIServer in $Target) {
                                         $VMhostPciDevices | Table -Name "$VMhost PCI Devices" 
                                     }
                                     #endregion ESXi Host PCI Devices
+
+                                    #region ESXi Host PCI Devices Details
+                                    Section -Style Heading5 'PCI Devices Drivers and Firmwares Details' {
+                                        
+                                        $VMhostPciDevicesDetails = Get-PCIdeviceDetail -Server $vCenter -esxcli $esxcli | Sort-Object 'VMKernel Name' 
+
+                                        $VMhostPciDevicesDetails | Table -Name "$VMhost PCI Devices Drivers and Firmwares Details" 
+                                    }
+                                    #endregion ESXi Host PCI Devices Details
                                 }
 
                                 #region ESXi Host System Section

--- a/Src/Public/Reports/vSphere/vSphere.ps1
+++ b/Src/Public/Reports/vSphere/vSphere.ps1
@@ -411,10 +411,10 @@ function Get-ScsiDeviceDetail {
     }
 }
 
-Function Get-PCIdeviceDetail {
+Function Get-PcideviceDetail {
     <#
     .SYNOPSIS
-    Helper function to return PCI device driver and firmware information for a specific host.
+    Helper function to return PCI Devices Drivers & Firmware information for a specific host.
     .PARAMETER Server
     vCenter VISession object.
     .PARAMETER esxcli
@@ -426,7 +426,7 @@ Function Get-PCIdeviceDetail {
     $esxcli = Get-EsxCli -Server $Server -VMHost $VMhost -V2
     Get-PCIdeviceDetail -Server $vCenter -esxcli $esxcli
 
-    VMKernel Name    : vmhba0
+    VMkernel Name    : vmhba0
     Device Name      : Sunrise Point-LP AHCI Controller
     Driver           : vmw_ahci
     Driver Version   : 1.0.0-34vmw.650.0.14.5146846
@@ -450,11 +450,11 @@ Function Get-PCIdeviceDetail {
     Process {
 
         # Set default results
-        $firmwareVersion = "NA"
-        $vibName = "NA"
+        $firmwareVersion = "N/A"
+        $vibName = "N/A"
         $driverVib = @{
-            Name = "NA"
-            Version = "NA"
+            Name = "N/A"
+            Version = "N/A"
         }
 
         $pciDevices = $esxcli.hardware.pci.list.Invoke() | Where-Object {$_.VMKernelName -like "vmhba*" -or $_.VMKernelName -like "vmnic*" -or $_.VMKernelName -like "vmgfx*"} | Sort-Object -Property VMKernelName 
@@ -496,7 +496,7 @@ Function Get-PCIdeviceDetail {
                 Output collected data
             #>
             [PSCustomObject]@{
-                'VMKernel Name'    = $pciDevice.VMKernelName
+                'VMkernel Name'    = $pciDevice.VMKernelName
                 'Device Name'      = $pciDevice.DeviceName
                 'Driver'           = $pciDevice.ModuleName
                 'Driver Version'   = $driverVersion
@@ -1010,14 +1010,12 @@ foreach ($VIServer in $Target) {
                                     }
                                     #endregion ESXi Host PCI Devices
 
-                                    #region ESXi Host PCI Devices Details
-                                    Section -Style Heading5 'PCI Devices Drivers and Firmwares Details' {
-                                        
-                                        $VMhostPciDevicesDetails = Get-PCIdeviceDetail -Server $vCenter -esxcli $esxcli | Sort-Object 'VMKernel Name' 
-
-                                        $VMhostPciDevicesDetails | Table -Name "$VMhost PCI Devices Drivers and Firmwares Details" 
+                                    #region ESXi Host PCI Devices Drivers & Firmware
+                                    Section -Style Heading5 'PCI Devices Drivers & Firmware' {
+                                        $VMhostPciDevicesDetails = Get-PcideviceDetail -Server $vCenter -esxcli $esxcli | Sort-Object 'VMKernel Name' 
+                                        $VMhostPciDevicesDetails | Table -Name "$VMhost PCI Devices Drivers & Firmware" 
                                     }
-                                    #endregion ESXi Host PCI Devices Details
+                                    #endregion ESXi Host PCI Devices Drivers & Firmware
                                 }
 
                                 #region ESXi Host System Section
@@ -1191,7 +1189,7 @@ foreach ($VIServer in $Target) {
                                         "network configuration of $VMhost.")
                                     BlankLine
                                     #region ESXi Host Network Configuration
-                                    $VMHostNetwork = $VMhost | Get-VMHostNetwork | Select-Object  VMHost, @{L = 'Virtual Switches'; E = {($_.VirtualSwitch) -join ", "}}, @{L = 'VMKernel Adapters'; E = {($_.VirtualNic) -join ", "}}, 
+                                    $VMHostNetwork = $VMhost | Get-VMHostNetwork | Select-Object  VMHost, @{L = 'Virtual Switches'; E = {($_.VirtualSwitch) -join ", "}}, @{L = 'VMkernel Adapters'; E = {($_.VirtualNic) -join ", "}}, 
                                     @{L = 'Physical Adapters'; E = {($_.PhysicalNic) -join ", "}}, @{L = 'VMKernel Gateway'; E = {$_.VMKernelGateway}}, @{L = 'IPv6 Enabled'; E = {$_.IPv6Enabled}}, 
                                     @{L = 'VMKernel IPv6 Gateway'; E = {$_.VMKernelV6Gateway}}, @{L = 'DNS Servers'; E = {($_.DnsAddress) -join ", "}}, @{L = 'Host Name'; E = {$_.HostName}}, 
                                     @{L = 'Domain Name'; E = {$_.DomainName}}, @{L = 'Search Domain'; E = {($_.SearchDomain) -join ", "}}


### PR DESCRIPTION
Ideas come from issue #19

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add PCI devices driver and firmware details for each host.

## Modifications
Add a new function named `Get-PCIdeviceDetail' whose role is to gather data about PCI devices, and more specifically the related drivers, firmwares and VIB.

Note: The code is heavily based on the work of the vDocumentation team. It's a lightweight version of the `Get-ESXIODevice.ps1` function.

https://github.com/arielsanchezmora/vDocumentation/blob/master/powershell/vDocumentation/Public/Get-ESXIODevice.ps1

## Related Issue
Related to issue #19.

## How Has This Been Tested?
For now, the code has been tested only with my lab.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/9823778/46699892-755ccf00-cc1b-11e8-98da-368bcbb1e482.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
