### PR TITLE
Handle a non-default multipath plugin

### DIFF
--- a/Reports/vSphere/CHANGELOG.md
+++ b/Reports/vSphere/CHANGELOG.md
@@ -1,5 +1,9 @@
 # VMware vSphere As Built Report Changelog
 
+## [Unreleased]
+### What's New
+- Corrected display of 3rd party Multipath Policy plugins
+
 ## 0.3.0
 ### What's New
 - Improvements to code structure & readability

--- a/Reports/vSphere/CHANGELOG.md
+++ b/Reports/vSphere/CHANGELOG.md
@@ -1,10 +1,6 @@
 # VMware vSphere As Built Report Changelog
 
-## [Unreleased]
-### What's New
-- Corrected display of 3rd party Multipath Policy plugins
-
-## 0.3.0
+## [Unreleased] / 0.3.0
 ### What's New
 - Improvements to code structure & readability
 - Improvements to output formatting
@@ -14,6 +10,7 @@
 - Corrected VMHost & VM uptime calculations
 - New Get-Uptime & Get-License functions
 - Added Cluster VM Overrides section
+- Corrected display of 3rd party Multipath Policy plugins
 
 ## 0.2.2
 ### What's New

--- a/Reports/vSphere/vSphere.ps1
+++ b/Reports/vSphere/vSphere.ps1
@@ -395,11 +395,6 @@ function Get-ScsiDeviceDetail {
         $DatastoreDiskName
     )
 
-    $PolicyLookup = @{
-        'VMW_PSP_RR' = 'Round Robin'
-        'VMW_PSP_FIXED' = 'Fixed'
-        'VMW_PSP_MRU' = 'Most Recently Used'
-    }
     $VMHostObj = $VMHosts | Where-Object {$_.Id -eq $VMHostMoRef}
     $ScsiDisk = $VMHostObj.ExtensionData.Config.StorageDevice.ScsiLun | Where-Object {
         $_.CanonicalName -eq $DatastoreDiskName
@@ -407,7 +402,12 @@ function Get-ScsiDeviceDetail {
     $Multipath = $VMHostObj.ExtensionData.Config.StorageDevice.MultipathInfo.Lun | Where-Object {
         $_.Lun -eq $ScsiDisk.Key
     }
-    $MultipathPolicy = $PolicyLookup."$($Multipath.Policy.Policy)"
+    switch ($Multipath.Policy.Policy) {
+        'VMW_PSP_RR' { $MultipathPolicy = 'Round Robin' }
+        'VMW_PSP_FIXED' { $MultipathPolicy = 'Fixed' }
+        'VMW_PSP_MRU' { $MultipathPolicy = 'Most Recently Used'}
+        default { $MultipathPolicy = $Multipath.Policy.Policy }
+    }
     $CapacityGB = [math]::Round((($ScsiDisk.Capacity.BlockSize * $ScsiDisk.Capacity.Block) / 1024 / 1024 / 1024), 2)
 
     [PSCustomObject]@{


### PR DESCRIPTION
## Description
If the multipath policy for a LUN is not one of the three built-in plugins, no value is displayed. Converted the lookup to a switch statement with a default to show the raw value if no others match.

## Related Issue
Fixes #61 

## Motivation and Context
Resolves missing data for affected environments.

## How Has This Been Tested?
Tested against an environment which uses the Nimble multipath plugin. Prior to change, LUN detail sections showed no Multipath Policy for Nimble datastores. After change, NIMBLE_PSP_DIRECTED is displayed.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
