### PR TITLE
Fix vSAN type and disk count for Hybrid clusters

### DIFF
--- a/Reports/vSphere/CHANGELOG.md
+++ b/Reports/vSphere/CHANGELOG.md
@@ -11,6 +11,7 @@
 - New Get-Uptime & Get-License functions
 - Added Cluster VM Overrides section
 - Corrected display of 3rd party Multipath Policy plugins
+- Corrected vSAN type & disk count
 
 ## 0.2.2
 ### What's New

--- a/Reports/vSphere/vSphere.ps1
+++ b/Reports/vSphere/vSphere.ps1
@@ -2395,11 +2395,12 @@ foreach ($VIServer in $Target) {
                                 $NumVsanDiskGroup = $VsanDiskGroup.Count
                                 $Script:VsanDisk = Get-vSanDisk -VsanDiskGroup $VsanDiskGroup
                                 $VsanDiskFormat = $VsanDisk.DiskFormatVersion | Select-Object -First 1 -Unique
-                                $NumVsanDisk = ($VsanDisk | Where-Object {$_.IsSsd -eq $true}).Count
-                                if ($VsanDisk.IsSsd -eq $true -and $VsanDisk.IsCacheDisk -eq $false) {
-                                    $VsanClusterType = "All-Flash"
-                                } else {
+                                $NumVsanSsd = ($VsanDisk | Where-Object {$_.IsSsd -eq $true}).Count
+                                $NumVsanHdd = ($VsanDisk | Where-Object {$_.IsSsd -eq $false}).Count
+                                if ($NumVsanHdd -gt 0) {
                                     $VsanClusterType = "Hybrid"
+                                } else {
+                                    $VsanClusterType = "All-Flash"
                                 }
                                 $VsanClusterDetail = [PSCustomObject]@{
                                     'Name' = $VsanCluster.Name
@@ -2411,7 +2412,7 @@ foreach ($VIServer in $Target) {
                                     }
                                     'Number of Hosts' = $VsanCluster.Cluster.ExtensionData.Host.Count
                                     'Disk Format Version' = $VsanDiskFormat
-                                    'Total Number of Disks' = $NumVsanDisk
+                                    'Total Number of Disks' = $NumVsanSsd + $NumVsanHdd
                                     'Total Number of Disk Groups' = $NumVsanDiskGroup
                                     'Disk Claim Mode' = $VsanCluster.VsanDiskClaimMode
                                     'Deduplication & Compression' = Switch ($VsanCluster.SpaceEfficiencyEnabled) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Corrects the vSAN Total Disk Count, which previously was only counting SSDs
* Correct vSAN type detection; would return All-Flash for a Hybrid cluster

## Related Issue
Fixes #63

## How Has This Been Tested?
Tested with a Hybrid and All-Flash vSAN lab cluster to verify the report is showing the correct type and disk count.

## Screenshots:
Correct information from a Hybrid vSAN:
![correct-hyb](https://user-images.githubusercontent.com/6922515/51512552-81d4f400-1dd4-11e9-8fb1-c5c6c19d1390.png)

Correct information from an All-Flash vSAN:
![correct-af](https://user-images.githubusercontent.com/6922515/51512555-88636b80-1dd4-11e9-8294-775d052757de.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
