### PR TITLE
Add parameter ReportConfigFile to allow custom report config

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ PS C:\>New-AsBuiltReport -IP 192.168.1.100 -Username admin -Password admin -Type
 
 # The following creates a VMware vSphere As-Built report in HTML format, using the configuration in the asbuilt.json file located in the C:\scripts\ folder.
 PS C:\>New-AsBuiltReport -IP 192.168.1.100 -Username admin -Password admin -Format HTML -Type vSphere -AsBuiltConfigPath C:\scripts\asbuilt.json
+# The following creates a VMware vSphere As-Built report in HTML format, using the detail configuration specified in the vSphere.json file located in the C:\scripts\ folder.
+PS C:\>New-AsBuiltReport -Target 192.168.1.100 -Credentials $Creds -Format Word -Type vSphere -ReportConfigFile C:\scripts\vSphere.json
 ```
 
 # Reports

--- a/Src/Public/New-AsBuiltReport.ps1
+++ b/Src/Public/New-AsBuiltReport.ps1
@@ -119,7 +119,9 @@ function New-AsBuiltReport {
         [Parameter(Mandatory = $False, HelpMessage = 'Specify whether to send report via Email')]
         [Switch]$SendEmail = $False,
         [Parameter(Mandatory = $False, HelpMessage = 'Provide the file path to an existing As Built Configuration JSON file')]
-        [string]$AsBuiltConfigPath
+        [string]$AsBuiltConfigPath,
+        [Parameter(Mandatory = $False, HelpMessage = 'Provide path to custom Report Configuration JSON file')]
+        [string]$ReportConfigFile
     )
     #endregion Script Parameters
     Clear-Host
@@ -145,7 +147,10 @@ function New-AsBuiltReport {
     }
 
     # Set variables from report configuration JSON file
-    $ReportConfigFile = "$PSScriptRoot\Reports\$Type\$Type.json"
+    if(!$ReportConfigFile){
+        $ReportConfigFile = "$PSScriptRoot\Reports\$Type\$Type.json"
+    }
+    
     If (Test-Path $ReportConfigFile -ErrorAction SilentlyContinue) {  
         $ReportConfig = Get-Content $ReportConfigFile -Raw | ConvertFrom-json
         $Report = $ReportConfig.Report


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add parameter to allow custom ReportConfigFile. If the custom file isn't provided, ti defaults to the original location at  "$PSScriptRoot\Reports\$Type\$Type.json"
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allow script to run with different details needed at different times.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested against 6.7 vCenter
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
